### PR TITLE
[CM-587][Do not merge] Allow resolving uid2 and custom attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "prebid.js",
-      "version": "7.15.0-pre",
+      "version": "7.16.0-pre",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.7",
@@ -22,7 +22,7 @@
         "express": "^4.15.4",
         "fun-hooks": "^0.9.9",
         "just-clone": "^1.0.2",
-        "live-connect-js": "2.3.3"
+        "live-connect-js": "2.4.0-alpha.1"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.5",
@@ -14416,9 +14416,9 @@
       "dev": true
     },
     "node_modules/live-connect-js": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-2.3.3.tgz",
-      "integrity": "sha512-WfY6v1jVutW/OGPvm0OaWAHc0MvB5MDdSuniZ+n9cpCltArWHTJtAsjWe8T+ACmdLAlZS9z7hzL3ntLnq+J0yQ==",
+      "version": "2.4.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-2.4.0-alpha.1.tgz",
+      "integrity": "sha512-5MB+CZE8uL40xk69+GqsVEScXlK3vbhVxDkAY0eV1qbrBmeC7JUd1b9uZA5mx9r6tjR2KEa36eqw31JexJ/aQw==",
       "dependencies": {
         "tiny-hashes": "1.0.1"
       },
@@ -33706,9 +33706,9 @@
       "dev": true
     },
     "live-connect-js": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-2.3.3.tgz",
-      "integrity": "sha512-WfY6v1jVutW/OGPvm0OaWAHc0MvB5MDdSuniZ+n9cpCltArWHTJtAsjWe8T+ACmdLAlZS9z7hzL3ntLnq+J0yQ==",
+      "version": "2.4.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-2.4.0-alpha.1.tgz",
+      "integrity": "sha512-5MB+CZE8uL40xk69+GqsVEScXlK3vbhVxDkAY0eV1qbrBmeC7JUd1b9uZA5mx9r6tjR2KEa36eqw31JexJ/aQw==",
       "requires": {
         "tiny-hashes": "1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "express": "^4.15.4",
     "fun-hooks": "^0.9.9",
     "just-clone": "^1.0.2",
-    "live-connect-js": "2.3.3"
+    "live-connect-js": "2.4.0-alpha.1"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"

--- a/test/spec/modules/liveIntentIdMinimalSystem_spec.js
+++ b/test/spec/modules/liveIntentIdMinimalSystem_spec.js
@@ -64,7 +64,7 @@ describe('LiveIntentMinimalId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId({ params: {...defaultConfigParams.params, ...{'url': 'https://dummy.liveintent.com/idex'}} }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/prebid/89899');
+    expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/prebid/89899?resolve=nonId');
     request.respond(
       200,
       responseHeader,
@@ -85,7 +85,7 @@ describe('LiveIntentMinimalId', function() {
     } }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/rubicon/89899');
+    expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/rubicon/89899?resolve=nonId');
     request.respond(
       200,
       responseHeader,
@@ -100,7 +100,7 @@ describe('LiveIntentMinimalId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899');
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?resolve=nonId');
     request.respond(
       200,
       responseHeader,
@@ -115,7 +115,7 @@ describe('LiveIntentMinimalId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899');
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?resolve=nonId');
     request.respond(
       503,
       responseHeader,
@@ -132,7 +132,7 @@ describe('LiveIntentMinimalId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?duid=${oldCookie}`);
+    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?duid=${oldCookie}&resolve=nonId`);
     request.respond(
       200,
       responseHeader,
@@ -155,7 +155,7 @@ describe('LiveIntentMinimalId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?duid=${oldCookie}&_thirdPC=third-pc`);
+    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?duid=${oldCookie}&_thirdPC=third-pc&resolve=nonId`);
     request.respond(
       200,
       responseHeader,
@@ -177,12 +177,44 @@ describe('LiveIntentMinimalId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?_thirdPC=%7B%22key%22%3A%22value%22%7D');
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?_thirdPC=%7B%22key%22%3A%22value%22%7D&resolve=nonId');
     request.respond(
       200,
       responseHeader,
       JSON.stringify({})
     );
     expect(callBackSpy.calledOnce).to.be.true;
+  });
+
+  it('should decode a unifiedId to lipbId and remove it', function() {
+    const result = liveIntentIdSubmodule.decode({ unifiedId: 'data' });
+    expect(result).to.eql({'lipb': {'lipbid': 'data'}});
+  });
+
+  it('should decode a nonId to lipbId', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'data' });
+    expect(result).to.eql({'lipb': {'lipbid': 'data', 'nonId': 'data'}});
+  });
+
+  it('should resolve extra attributes', function() {
+    let callBackSpy = sinon.spy();
+    let submoduleCallback = liveIntentIdSubmodule.getId({ params: {
+      ...defaultConfigParams.params,
+      ...{ extraRequestedAttributes: ['foo'] }
+    } }).callback;
+    submoduleCallback(callBackSpy);
+    let request = server.requests[0];
+    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?resolve=nonId&resolve=foo`);
+    request.respond(
+      200,
+      responseHeader,
+      JSON.stringify({})
+    );
+    expect(callBackSpy.calledOnce).to.be.true;
+  });
+
+  it('should decode a uid2 to a seperate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', uid2: 'bar' });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'uid2': 'bar'}, 'uid2': {'id': 'bar'}});
   });
 });

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -133,7 +133,7 @@ describe('LiveIntentId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId({ params: {...defaultConfigParams.params, ...{'url': 'https://dummy.liveintent.com/idex'}} }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[1];
-    expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/prebid/89899');
+    expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/prebid/89899?resolve=nonId');
     request.respond(
       204,
       responseHeader
@@ -153,7 +153,7 @@ describe('LiveIntentId', function() {
     } }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[1];
-    expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/rubicon/89899');
+    expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/rubicon/89899?resolve=nonId');
     request.respond(
       200,
       responseHeader,
@@ -168,7 +168,7 @@ describe('LiveIntentId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[1];
-    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899');
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?resolve=nonId');
     request.respond(
       200,
       responseHeader,
@@ -183,7 +183,7 @@ describe('LiveIntentId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[1];
-    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899');
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?resolve=nonId');
     request.respond(
       503,
       responseHeader,
@@ -200,7 +200,7 @@ describe('LiveIntentId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[1];
-    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?duid=${oldCookie}`);
+    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?duid=${oldCookie}&resolve=nonId`);
     request.respond(
       200,
       responseHeader,
@@ -223,7 +223,7 @@ describe('LiveIntentId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[1];
-    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?duid=${oldCookie}&_thirdPC=third-pc`);
+    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?duid=${oldCookie}&_thirdPC=third-pc&resolve=nonId`);
     request.respond(
       200,
       responseHeader,
@@ -245,7 +245,7 @@ describe('LiveIntentId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[1];
-    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?_thirdPC=%7B%22key%22%3A%22value%22%7D');
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?_thirdPC=%7B%22key%22%3A%22value%22%7D&resolve=nonId');
     request.respond(
       200,
       responseHeader,
@@ -258,5 +258,37 @@ describe('LiveIntentId', function() {
     getCookieStub.throws('CookieError', 'A message');
     liveIntentIdSubmodule.getId(defaultConfigParams);
     expect(imgStub.getCall(0).args[0]).to.match(/.*ae=.+/);
+  });
+
+  it('should decode a unifiedId to lipbId and remove it', function() {
+    const result = liveIntentIdSubmodule.decode({ unifiedId: 'data' });
+    expect(result).to.eql({'lipb': {'lipbid': 'data'}});
+  });
+
+  it('should decode a nonId to lipbId', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'data' });
+    expect(result).to.eql({'lipb': {'lipbid': 'data', 'nonId': 'data'}});
+  });
+
+  it('should resolve extra attributes', function() {
+    let callBackSpy = sinon.spy();
+    let submoduleCallback = liveIntentIdSubmodule.getId({ params: {
+      ...defaultConfigParams.params,
+      ...{ extraRequestedAttributes: ['foo'] }
+    } }).callback;
+    submoduleCallback(callBackSpy);
+    let request = server.requests[1];
+    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?resolve=nonId&resolve=foo`);
+    request.respond(
+      200,
+      responseHeader,
+      JSON.stringify({})
+    );
+    expect(callBackSpy.calledOnce).to.be.true;
+  });
+
+  it('should decode a uid2 to a seperate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', uid2: 'bar' });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'uid2': 'bar'}, 'uid2': {'id': 'bar'}});
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Update the UserId module to the newest version of our library and allow resolving additional attributes.

When we are asked to resolve `uid2`, we will expose it in the same format as the existing uid2 module. This was discussed with The Trade Desk and they are fine with this approach (<todo> cc tdd person here).
Note that the modules will be evaluated in lexicographical order, so the uid2 module will overwrite any data that was resolved by us if it is also enabled.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
