### PR TITLE
CM-888 - Backport magnite id support

### DIFF
--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -200,6 +200,10 @@ export const liveIntentIdSubmodule = {
         result.medianet = { 'id': value.medianet }
       }
 
+      if (value.magnite) {
+        result.magnite = { 'id': value.magnite }
+      }
+
       return result
     }
 

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -170,6 +170,15 @@ export const USER_IDS_CONFIG = {
     }
   },
 
+  // magnite
+  'magnite': {
+    source: 'rubiconproject.com',
+    atype: 3,
+    getValue: function(data) {
+      return data.id;
+    }
+  },
+
   // britepoolId
   'britepoolid': {
     source: 'britepool.com',

--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -123,6 +123,14 @@ userIdAsEids = [
     },
 
     {
+        source: 'rubiconproject.com',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 3
+        }]
+    },
+
+    {
         source: 'merkleinc.com',
         uids: [{
             id: 'some-random-id-value',

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -216,6 +216,21 @@ describe('eids array generation for known sub-modules', function() {
     });
   });
 
+  it('magnite', function() {
+    const userId = {
+      magnite: {'id': 'sample_id'}
+    };
+    const newEids = createEidsArray(userId);
+    expect(newEids.length).to.equal(1);
+    expect(newEids[0]).to.deep.equal({
+      source: 'rubiconproject.com',
+      uids: [{
+        id: 'sample_id',
+        atype: 3
+      }]
+    });
+  });
+
   it('britepoolId', function() {
     const userId = {
       britepoolid: 'some-random-id-value'

--- a/test/spec/modules/liveIntentIdMinimalSystem_spec.js
+++ b/test/spec/modules/liveIntentIdMinimalSystem_spec.js
@@ -251,6 +251,11 @@ describe('LiveIntentMinimalId', function() {
     expect(result).to.eql({'uid2': {'id': 'bar'}});
   });
 
+  it('should decode a magnite id to a seperate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', magnite: 'bar' });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'magnite': 'bar'}, 'magnite': {'id': 'bar'}});
+  });
+
   it('should allow disabling nonId resolution', function() {
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId({ params: {

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -368,6 +368,11 @@ describe('LiveIntentId', function() {
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'medianet': 'bar'}, 'medianet': {'id': 'bar'}});
   });
 
+  it('should decode a magnite id to a seperate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', magnite: 'bar' });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'magnite': 'bar'}, 'magnite': {'id': 'bar'}});
+  });
+
   it('should decode values with uid2 but no nonId', function() {
     const result = liveIntentIdSubmodule.decode({ uid2: 'bar' });
     expect(result).to.eql({'uid2': {'id': 'bar'}});


### PR DESCRIPTION
Magnite id support was released as Part of Prebid version 8.2. There are some customers that do not want to upgrade just now, but would like to be able to use the magnite it, this PR backports this feaure.

Ticket: https://liveintent.atlassian.net/browse/CM-888