### PR TITLE
LiveIntent UserId module: update LiveConnect dependency; fix caching bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "express": "^4.15.4",
         "fun-hooks": "^0.9.9",
         "just-clone": "^1.0.2",
-        "live-connect-js": "^5.0.0"
+        "live-connect-js": "^6.2.4"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.5",
@@ -16232,23 +16232,23 @@
       "dev": true
     },
     "node_modules/live-connect-common": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-1.0.0.tgz",
-      "integrity": "sha512-LBZsvykcGeVRYI1eqqXrrNZsoBdL2a8cpyrYPIiGAF/CpixbyRbvqGslaFw511lH294QB16J3fYYg21aYuaM2Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-3.0.2.tgz",
+      "integrity": "sha512-K3LNKd9CpREDJbXGdwKqPojjQaxd4G6c7OAD6Yzp3wsCWTH2hV8xNAbUksSOpOcVyyOT9ilteEFXIJQJrbODxQ==",
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
     },
     "node_modules/live-connect-js": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-5.0.0.tgz",
-      "integrity": "sha512-Bv0wQQ+/1VU0/YczEpObbWtHbuXwaHGxwg1+Pe7ZlDgBLb334CrqSQvOL1uyZw3//zs+fSO94yYaQzjjkTd5OQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.2.4.tgz",
+      "integrity": "sha512-fjNzKxbtmHSCsPT27UANOf66fVizJkhgSzAj5Ej9X6sYRiox+NClM2VdRSf4eL54BabJznPLEWzWT/s4ZVVWsQ==",
       "dependencies": {
-        "live-connect-common": "^1.0.0",
+        "live-connect-common": "^v3.0.2",
         "tiny-hashes": "1.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
     },
     "node_modules/livereload-js": {
@@ -37883,16 +37883,16 @@
       "dev": true
     },
     "live-connect-common": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-1.0.0.tgz",
-      "integrity": "sha512-LBZsvykcGeVRYI1eqqXrrNZsoBdL2a8cpyrYPIiGAF/CpixbyRbvqGslaFw511lH294QB16J3fYYg21aYuaM2Q=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-3.0.2.tgz",
+      "integrity": "sha512-K3LNKd9CpREDJbXGdwKqPojjQaxd4G6c7OAD6Yzp3wsCWTH2hV8xNAbUksSOpOcVyyOT9ilteEFXIJQJrbODxQ=="
     },
     "live-connect-js": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-5.0.0.tgz",
-      "integrity": "sha512-Bv0wQQ+/1VU0/YczEpObbWtHbuXwaHGxwg1+Pe7ZlDgBLb334CrqSQvOL1uyZw3//zs+fSO94yYaQzjjkTd5OQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.2.4.tgz",
+      "integrity": "sha512-fjNzKxbtmHSCsPT27UANOf66fVizJkhgSzAj5Ej9X6sYRiox+NClM2VdRSf4eL54BabJznPLEWzWT/s4ZVVWsQ==",
       "requires": {
-        "live-connect-common": "^1.0.0",
+        "live-connect-common": "^v3.0.2",
         "tiny-hashes": "1.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "express": "^4.15.4",
     "fun-hooks": "^0.9.9",
     "just-clone": "^1.0.2",
-    "live-connect-js": "^5.0.0"
+    "live-connect-js": "^6.2.4"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Resolution result caching had a bug that under certain circumstances lead to resolving the wrong set of ids in cases where multiple LiveConnect instances were present on a page. The bug has been fixed in the live-connect module. In Prebid, only the module version pump but no code changes are required. 

## Other information
- PR for fixing the cache: https://github.com/LiveIntent/live-connect/pull/215
