### PR TITLE
CM-1148 - Use built-in sampling

### DIFF
--- a/modules/liveIntentAnalyticsAdapter.js
+++ b/modules/liveIntentAnalyticsAdapter.js
@@ -10,11 +10,8 @@ const ANALYTICS_TYPE = 'endpoint';
 const URL = 'https://wba.liadm.com/analytic-events';
 const GVL_ID = 148;
 const ADAPTER_CODE = 'liveintent';
-const DEFAULT_SAMPLING = 0.1;
 const DEFAULT_BID_WON_TIMEOUT = 2000;
 const { EVENTS: { AUCTION_END } } = CONSTANTS;
-let initOptions = {};
-let isSampled;
 let bidWonTimeout;
 
 function handleAuctionEnd(args) {
@@ -123,19 +120,15 @@ function ignoreUndefined(data) {
 
 let liAnalytics = Object.assign(adapter({URL, ANALYTICS_TYPE}), {
   track({ eventType, args }) {
-    if (eventType == AUCTION_END && args && isSampled) { handleAuctionEnd(args); }
+    if (eventType == AUCTION_END && args) { handleAuctionEnd(args); }
   }
 });
 
 // save the base class function
 liAnalytics.originEnableAnalytics = liAnalytics.enableAnalytics;
-
 // override enableAnalytics so we can get access to the config passed in from the page
 liAnalytics.enableAnalytics = function (config) {
-  initOptions = config.options;
-  const sampling = (initOptions && initOptions.sampling) ?? DEFAULT_SAMPLING;
-  isSampled = Math.random() < parseFloat(sampling);
-  bidWonTimeout = (initOptions && initOptions.bidWonTimeout) ?? DEFAULT_BID_WON_TIMEOUT;
+  bidWonTimeout = config?.options?.bidWonTimeout ?? DEFAULT_BID_WON_TIMEOUT;
   liAnalytics.originEnableAnalytics(config); // call the base class function
 };
 

--- a/test/spec/modules/liveIntentAnalyticsAdapter_spec.js
+++ b/test/spec/modules/liveIntentAnalyticsAdapter_spec.js
@@ -16,11 +16,19 @@ let events = require('src/events');
 let constants = require('src/constants.json');
 let auctionId = '99abbc81-c1f1-41cd-8f25-f7149244c897'
 
-const config = {
+const configWithSamplingAll = {
   provider: 'liveintent',
   options: {
     bidWonTimeout: 2000,
     sampling: 1
+  }
+}
+
+const configWithSamplingNone = {
+  provider: 'liveintent',
+  options: {
+    bidWonTimeout: 2000,
+    sampling: 0
   }
 }
 
@@ -273,8 +281,8 @@ describe('LiveIntent Analytics Adapter ', () => {
     clock.restore();
   });
 
-  it('request is computed and sent correctly', () => {
-    liAnalytics.enableAnalytics(config);
+  it('request is computed and sent correctly when sampling is 1', () => {
+    liAnalytics.enableAnalytics(configWithSamplingAll);
     sandbox.stub(utils, 'generateUUID').returns(instanceId);
     sandbox.stub(refererDetection, 'getRefererInfo').returns({page: url});
     sandbox.stub(auctionManager.index, 'getAuction').withArgs(auctionId).returns({ getWinningBids: () => winningBids });
@@ -288,7 +296,23 @@ describe('LiveIntent Analytics Adapter ', () => {
 
   it('track is called', () => {
     sandbox.stub(liAnalytics, 'track');
-    liAnalytics.enableAnalytics(config);
+    liAnalytics.enableAnalytics(configWithSamplingAll);
     expectEvents().to.beTrackedBy(liAnalytics.track);
+  })
+
+  it('no request is computed when sampling is 0', () => {
+    liAnalytics.enableAnalytics(configWithSamplingNone);
+    sandbox.stub(utils, 'generateUUID').returns(instanceId);
+    sandbox.stub(refererDetection, 'getRefererInfo').returns({page: url});
+    sandbox.stub(auctionManager.index, 'getAuction').withArgs(auctionId).returns({ getWinningBids: () => winningBids });
+    events.emit(constants.EVENTS.AUCTION_END, args);
+    clock.tick(2000);
+    expect(server.requests.length).to.equal(0);
+  });
+
+  it('track is not called', () => {
+    sandbox.stub(liAnalytics, 'track');
+    liAnalytics.enableAnalytics(configWithSamplingNone);
+    sinon.assert.callCount(liAnalytics.track, 0);
   })
 });


### PR DESCRIPTION
Additionally to what is written in the [ticket](https://liveintent.atlassian.net/browse/CM-1148), from what I see in the [code](https://github.com/prebid/Prebid.js/blob/master/libraries/analyticsAdapter/AnalyticsAdapter.js#L108) and in the [docs](https://docs.prebid.org/dev-docs/modules/genericAnalyticsAdapter.html), we can just rely on built-in the `sampling` handling. 