### PR TITLE
CM-1660 - Make auctionId an object field

### DIFF
--- a/modules/liveIntentAnalyticsAdapter.js
+++ b/modules/liveIntentAnalyticsAdapter.js
@@ -16,7 +16,7 @@ let bidWonTimeout;
 
 function handleAuctionEnd(args) {
   setTimeout(() => {
-    const auction = auctionManager.index.getAuction(args.auctionId);
+    const auction = auctionManager.index.getAuction({auctionId: args.auctionId});
     const winningBids = (auction) ? auction.getWinningBids() : [];
     const data = createAnalyticsEvent(args, winningBids);
     sendAnalyticsEvent(data);


### PR DESCRIPTION
When handling auction end events, our Analytics  Adapter attempts to get the whole auction information based on `auctionId`. However, the API to get the auction expects an object and not a scalar value. 

This eventually lead to no winning bids being reported.

Before changes (winning bids is always an empty array):

![Screen Shot 2025-02-10 at 3 06 17 PM](https://github.com/user-attachments/assets/745bf447-3814-48b5-b6f9-2e425793f0cd)

After changes (winning bids is filled when there was a winning bid):

![Screen Shot 2025-02-10 at 3 07 02 PM](https://github.com/user-attachments/assets/91975fcf-cec8-4550-ab60-83b4f643ba1a)


